### PR TITLE
[feat] add option to display clock time in vt

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,20 @@ Pass any of these settings to setup func to overwrite the defaults:
 
 ```lua
 require('due_nvim').setup {
-  prescript = 'due: '      -- prescript to due data
-  prescript_hi = 'Comment' -- highlight group of it
-  due_hi = 'String'        -- highlight group of the data itself
-  ft = '*.md'              -- filename template to apply aucmds :)
-  today = 'TODAY'          -- text for today's due
-  today_hi = 'Character'   -- highlight group of today's due
-  overdue = 'OVERDUE'      -- text for overdued
-  overdue_hi = 'Error'     -- highlight group of overdued
-  date_hi = 'Conceal'      -- highlight group of date string
-  pattern_start = '<'      -- start for a date string pattern
-  pattern_end = '>'        -- end for a date string pattern
+  prescript = 'due: '           -- prescript to due data
+  prescript_hi = 'Comment'      -- highlight group of it
+  due_hi = 'String'             -- highlight group of the data itself
+  ft = '*.md'                   -- filename template to apply aucmds :)
+  today = 'TODAY'               -- text for today's due
+  today_hi = 'Character'        -- highlight group of today's due
+  overdue = 'OVERDUE'           -- text for overdued
+  overdue_hi = 'Error'          -- highlight group of overdued
+  date_hi = 'Conceal'           -- highlight group of date string
+  pattern_start = '<'           -- start for a date string pattern
+  pattern_end = '>'             -- end for a date string pattern
+  use_clock_time = false        -- allow due.nvim to calculate hours, minutes, and seconds
+  default_due_time = "midnight" -- if use_clock_time == true, calculate time until option on specified date. 
+                                --   Accepts "midnight", for 23:59:59, or noon, for 12:00:00
 }
 ```
 

--- a/lua/due_nvim.lua
+++ b/lua/due_nvim.lua
@@ -1,27 +1,56 @@
 local M = {}
 _VT_NS = vim.api.nvim_create_namespace("lsp_signature")
 
+
 local function parseDue(due)
   local year = 31556926
   local month = 2629743
   local week = 604800
   local day = 86400
+  local hour = 3600
+  local minute = 60
   local res = ''
+
   if due >= year then
     res = res .. math.floor(due / year) .. 'y '
     due = due % year
   end
+
   if due >= month then
-    res = res .. math.floor(due / month) .. 'm '
+    res = res .. math.floor(due / month) .. 'mo '
     due = due % month
   end
+
   if due >= week then
     res = res .. math.floor(due / week) .. 'w '
     due = due % week
   end
-  res = res .. math.floor(due / day) + 1 .. 'd '
+
+  if use_clock_time == true then
+    if due >= day then
+      res = res .. math.floor(due / day) .. 'd '
+      due = due % day
+    end  
+
+    if due >= hour then
+      res = res .. math.floor(due / hour) .. 'h '
+      due = due % hour
+    end 
+
+    if due >= minute then
+      res = res .. math.floor(due / minute) .. 'mi '
+      due = due % minute
+    end  
+
+    res = res .. math.floor(due / 1) + 1 .. 's '
+
+  else
+    res = res .. math.floor(due / day) + 1 .. 'd '
+  end
+
   return res
 end
+
 
 local prescript
 local prescript_hi
@@ -40,18 +69,21 @@ local fulldate_pattern
 local date_pattern_match
 local fulldate_pattern_match
 
+
 function M.setup(c)
-  prescript = c.prescript and c.prescript or 'due: '
-  prescript_hi = c.prescript_hi and c.prescript_hi or 'Comment'
-  due_hi = c.due_hi and c.due_hi or 'String'
-  ft = c.ft and c.ft or '*.md'
-  today = c.today and c.today or 'TODAY'
-  today_hi = c.today_hi and c.today_hi or 'Character'
-  overdue = c.overdue and c.overdue or 'OVERDUE'
-  overdue_hi = c.overdue_hi and c.overdue_hi or 'Error'
-  date_hi = c.date_hi and c.date_hi or 'Conceal'
-  pattern_start = c.pattern_start and c.pattern_start or '<'
-  pattern_end = c.pattern_end and c.pattern_end or '>'
+  use_clock_time = c.use_clock_time or false
+  default_due_time = c.default_due_time or 'midnight'
+  prescript = c.prescript or 'due: '
+  prescript_hi = c.prescript_hi or 'Comment'
+  due_hi = c.due_hi or 'String'
+  ft = c.ft or '*.md'
+  today = c.today or 'TODAY'
+  today_hi = c.today_hi or 'Character'
+  overdue = c.overdue or 'OVERDUE'
+  overdue_hi = c.overdue_hi or 'Error'
+  date_hi = c.date_hi or 'Conceal'
+  pattern_start = c.pattern_start or '<'
+  pattern_end = c.pattern_end or '>'
 
   local lua_start = pattern_start:gsub("[%(%)%.%%%+%-%*%?%[%^%$%]]", "%%%1")
   local lua_end = pattern_end:gsub("[%(%)%.%%%+%-%*%?%[%^%$%]]", "%%%1")
@@ -60,7 +92,9 @@ function M.setup(c)
   local regex_end = pattern_end:gsub("\\%^%$%.%*~%[%]&", "\\%1")
 
   date_pattern = lua_start .. '%d%d%-%d%d' .. lua_end
+  datetime_pattern = lua_start .. '%d%d%-%d%d-%d%d%:%d%d%:%d%d' .. lua_end
   fulldate_pattern = lua_start .. '%d%d%d%d%-%d%d%-%d%d' .. lua_end
+
   date_pattern_match = lua_start .. '(%d%d)%-(%d%d)' .. lua_end
   fulldate_pattern_match = lua_start .. '(%d%d%d%d)%-(%d%d)%-(%d%d)' .. lua_end
 
@@ -75,8 +109,28 @@ function M.setup(c)
   vim.api.nvim_command('autocmd BufEnter ' .. ft .. ' hi def link DueDate ' .. date_hi)
 end
 
+
 function M.draw(buf)
+  local user_time
+  local user_hour
+  local user_min
+  local user_sec
+
+  -- get user default time option
+  if default_due_time == "midnight" then
+    user_hour = 23 
+    user_min = 59 
+    user_sec = 59  
+  elseif default_due_time == "noon" then
+    user_hour = 12 
+    user_min = 00 
+    user_sec = 00   
+  end
+  
+  -- get current time
   local now = os.time(os.date('*t'))
+
+  -- find which date pattern is being passed in by user
   for key, value in pairs(vim.api.nvim_buf_get_lines(buf, 0, -1, {})) do
     local date = string.match(value, date_pattern)
     local fullDate = string.match(value, fulldate_pattern)
@@ -84,19 +138,27 @@ function M.draw(buf)
 
     if date then
       local month, day = date:match(date_pattern_match)
-      due = os.time({ year = os.date("%Y"), month = month, day = day }) - now
+      local cur_year = os.date("%Y")
+
+      user_time = os.time({ year = cur_year, month = month, day = day, hour = user_hour, min = user_min, sec = user_sec }) 
+
+      due = user_time - now
     end
 
     if fullDate then
-      local year, month, day = fullDate:match(fulldate_pattern_match)
-      due = os.time({ year = year, month = month, day = day }) - now
+      local cur_year, month, day = fullDate:match(fulldate_pattern_match)
+
+      user_time = os.time({ year = cur_year, month = month, day = day, hour = user_hour, min = user_min, sec = user_sec }) 
+
+      due = user_time - now
     end
 
     if due then
       local parsed
+
       if due > 0 then
         parsed = { parseDue(due), due_hi }
-      elseif due > -86400 then
+      elseif use_clock_time == false and due > -86400 then
         parsed = { today, today_hi }
       else
         parsed = { overdue, overdue_hi }
@@ -119,4 +181,4 @@ function M.redraw(buf)
   M.draw(buf)
 end
 
-return M
+return M 

--- a/lua/due_nvim.lua
+++ b/lua/due_nvim.lua
@@ -17,7 +17,7 @@ local function parseDue(due)
   end
 
   if due >= month then
-    res = res .. math.floor(due / month) .. 'mo '
+    res = res .. math.floor(due / month) .. 'm '
     due = due % month
   end
 
@@ -38,7 +38,7 @@ local function parseDue(due)
     end 
 
     if due >= minute then
-      res = res .. math.floor(due / minute) .. 'mi '
+      res = res .. math.floor(due / minute) .. 'min '
       due = due % minute
     end  
 
@@ -71,7 +71,7 @@ local fulldate_pattern_match
 
 
 function M.setup(c)
-  use_clock_time = c.use_clock_time or false
+  use_clock_time = c.use_clock_time or true
   default_due_time = c.default_due_time or 'midnight'
   prescript = c.prescript or 'due: '
   prescript_hi = c.prescript_hi or 'Comment'
@@ -92,7 +92,6 @@ function M.setup(c)
   local regex_end = pattern_end:gsub("\\%^%$%.%*~%[%]&", "\\%1")
 
   date_pattern = lua_start .. '%d%d%-%d%d' .. lua_end
-  datetime_pattern = lua_start .. '%d%d%-%d%d-%d%d%:%d%d%:%d%d' .. lua_end
   fulldate_pattern = lua_start .. '%d%d%d%d%-%d%d%-%d%d' .. lua_end
 
   date_pattern_match = lua_start .. '(%d%d)%-(%d%d)' .. lua_end
@@ -158,7 +157,7 @@ function M.draw(buf)
 
       if due > 0 then
         parsed = { parseDue(due), due_hi }
-      elseif use_clock_time == false and due > -86400 then
+      elseif not use_clock_time and due > -86400 then
         parsed = { today, today_hi }
       else
         parsed = { overdue, overdue_hi }
@@ -181,4 +180,4 @@ function M.redraw(buf)
   M.draw(buf)
 end
 
-return M 
+return M


### PR DESCRIPTION
what:
   - add two new options
      - 1. use_clock_time: this option allows the user to include the time in their due date virtual text. 
      - 2. default_due_time: if the user sets use_clock_time to true, this option sets a default due time.
         - currently, the only two options are midnight and noon
            - midnight sets the clock to 11:59:59 pm, e.g. if the user sets the due date to <01-01>, the virtual
              text will count the hours until 11:59:59 pm (23:59:59) in 01-01
            - noon does the same as above, but with noon
              
why:
   - this allows the user to have a slightly more specific due date time. It is a band-aid until a more experienced
     author allows for parsing time patterns 

known issues:
    - when using clock time, hours are off when year is increased. 