### PR TITLE
fix use_clock_today

### DIFF
--- a/lua/due_nvim.lua
+++ b/lua/due_nvim.lua
@@ -101,7 +101,7 @@ end
 function M.setup(c)
   c = c or {}
   use_clock_time = c.use_clock_time or false
-  use_clock_today = c.use_clock_time or false
+  use_clock_today = c.use_clock_today or false
   if type(c.use_seconds) == 'boolean' then
     use_seconds = c.use_seconds
   else


### PR DESCRIPTION
use_clock_today was checking the wrong config option (use_clock_time), causing it to never be properly activated.